### PR TITLE
Fix build on macOS

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -22,7 +22,10 @@
       "defines": [
         "NODE_ADDON_API_DISABLE_DEPRECATED",
         "NAPI_VERSION=<(napi_build_version)"
-      ]
+      ],
+      "xcode_settings": {
+        "GCC_ENABLE_CPP_EXCEPTIONS": "YES"
+      }
     }
   ]
 }


### PR DESCRIPTION
Without this flag, Node will attempt to build without exceptions on macOS, which fails because exceptions are used in the wrapper.